### PR TITLE
fix(apv): Escape description

### DIFF
--- a/UltiSnips/yaml.snippets
+++ b/UltiSnips/yaml.snippets
@@ -189,7 +189,7 @@ spec:
       storage: ${9:20Gi}
 endsnippet
 
-snippet apv azure_persistent_volume
+snippet apv "azure_persistent_volume"
 apiVersion: v1
 kind: PersistentVolume
 metadata:


### PR DESCRIPTION
Prevent following error
UltiSnips Error:

Invalid multiword trigger: 'apv azure_persistent_volume' in .....vim-kubernetes/UltiSnips/yaml.snippets:192